### PR TITLE
Fix docs, path handling, add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,9 @@ bash
 python ml/train_aethercore1.py
 
 
- Start API Server (Coming Soon)
+Start API Server (Coming Soon)
 
-bash
-uvicorn api.main:app --reload
+API module not yet implemented
 
 
  Launch Backoffice UI (Planned)
@@ -118,7 +117,7 @@ If you want to contribute:
  💬 Contact
 
 * Maintainer: Athul P. Sudheer
-* Email: )] athulpsudheer@gmail.com
+* Email: athulpsudheer@gmail.com
 * GitHub: [https://github.com/yourusername/AetherQuant](https://github.com/callmeATHUL/AetherQuant)
 
 ---

--- a/ml/train_aethercore1.py
+++ b/ml/train_aethercore1.py
@@ -2,6 +2,7 @@ import pandas as pd
 import os
 import joblib
 import logging
+from pathlib import Path
 from lightgbm import LGBMClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import classification_report, accuracy_score
@@ -14,12 +15,16 @@ print(f"📁 Current Working Directory: {os.getcwd()}")
 logging.basicConfig(level=logging.INFO)
 
 
-def load_features(path="processed/BTCUSDT_4h_features.parquet"):
-	if not os.path.exists(path):
-		raise FileNotFoundError(f"Feature file not found at {path}")
-	df = pd.read_parquet(path)
-	logging.info(f"📦 Loaded feature data: {df.shape[0]} rows")
-	return df
+def load_features(path=None):
+        if path is None:
+                base = Path(__file__).resolve().parent / "processed"
+                path = base / "BTCUSDT_4h_features.parquet"
+        path = Path(path)
+        if not path.exists():
+                raise FileNotFoundError(f"Feature file not found at {path}")
+        df = pd.read_parquet(path)
+        logging.info(f"📦 Loaded feature data: {df.shape[0]} rows")
+        return df
 
 
 def prepare_data(df):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ ta
 joblib
 lightgbm
 sklearn
+pytest

--- a/tests/test_triple_barrier.py
+++ b/tests/test_triple_barrier.py
@@ -1,0 +1,10 @@
+import pandas as pd
+from data.features.triple_barrier import triple_barrier_labels
+
+
+def test_triple_barrier_basic():
+    df = pd.DataFrame({"Close": [100, 106, 95, 110, 90]})
+    result = triple_barrier_labels(df, pt=0.05, sl=0.05, horizon=2)
+    assert result["label"].iloc[0] == 1
+    assert result["label"].iloc[1] == -1
+


### PR DESCRIPTION
## Summary
- fix stray characters in contact email
- clarify that the API module isn't implemented
- ensure training script finds the feature file relative to its location
- add pytest-based check for triple barrier labels
- include pytest dependency

## Testing
- `pytest -q tests/test_triple_barrier.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6848d7d0af708324ad9631c51f626159